### PR TITLE
support linking to GitHub paths from purls

### DIFF
--- a/internal/apk/purl.go
+++ b/internal/apk/purl.go
@@ -70,7 +70,11 @@ func (p *purl) url(repo string) (string, error) {
 		}
 		return fmt.Sprintf("/%s%s%s%s", h, repository, delim, p.version), nil
 	case "github":
-		return fmt.Sprintf("https://github.com/%s/%s/tree/%s", p.namespace, p.name, p.version), nil
+		if p.subpath == "" {
+			return fmt.Sprintf("https://github.com/%s/%s/tree/%s", p.namespace, p.name, p.version), nil
+		} else {
+			return fmt.Sprintf("https://github.com/%s/%s/blob/%s/%s", p.namespace, p.name, p.version, p.subpath), nil
+		}
 	case "bitbucket":
 		return fmt.Sprintf("https://www.bitbucket.org/%s/%s/changeset/%s", p.namespace, p.name, p.version), nil
 	case "apk":

--- a/internal/apk/purl.go
+++ b/internal/apk/purl.go
@@ -70,11 +70,7 @@ func (p *purl) url(repo string) (string, error) {
 		}
 		return fmt.Sprintf("/%s%s%s%s", h, repository, delim, p.version), nil
 	case "github":
-		if p.subpath == "" {
-			return fmt.Sprintf("https://github.com/%s/%s/tree/%s", p.namespace, p.name, p.version), nil
-		} else {
-			return fmt.Sprintf("https://github.com/%s/%s/blob/%s/%s", p.namespace, p.name, p.version, p.subpath), nil
-		}
+		return "https://github.com/" + path.Join(p.namespace, p.name, "tree", p.version, p.subpath), nil
 	case "bitbucket":
 		return fmt.Sprintf("https://www.bitbucket.org/%s/%s/changeset/%s", p.namespace, p.name, p.version), nil
 	case "apk":

--- a/internal/explore/purl.go
+++ b/internal/explore/purl.go
@@ -81,7 +81,11 @@ func (p *purl) url(repo string) (string, error) {
 		}
 		return fmt.Sprintf("/%s%s%s%s", h, repository, delim, p.version), nil
 	case "github":
-		return fmt.Sprintf("https://github.com/%s/%s/tree/%s", p.namespace, p.name, p.version), nil
+		if p.subpath == "" {
+			return fmt.Sprintf("https://github.com/%s/%s/tree/%s", p.namespace, p.name, p.version), nil
+		} else {
+			return fmt.Sprintf("https://github.com/%s/%s/blob/%s/%s", p.namespace, p.name, p.version, p.subpath), nil
+		}
 	case "bitbucket":
 		return fmt.Sprintf("https://www.bitbucket.org/%s/%s/changeset/%s", p.namespace, p.name, p.version), nil
 	case "apk":

--- a/internal/explore/purl.go
+++ b/internal/explore/purl.go
@@ -81,11 +81,7 @@ func (p *purl) url(repo string) (string, error) {
 		}
 		return fmt.Sprintf("/%s%s%s%s", h, repository, delim, p.version), nil
 	case "github":
-		if p.subpath == "" {
-			return fmt.Sprintf("https://github.com/%s/%s/tree/%s", p.namespace, p.name, p.version), nil
-		} else {
-			return fmt.Sprintf("https://github.com/%s/%s/blob/%s/%s", p.namespace, p.name, p.version, p.subpath), nil
-		}
+		return "https://github.com/" + path.Join(p.namespace, p.name, "tree", p.version, p.subpath), nil
 	case "bitbucket":
 		return fmt.Sprintf("https://www.bitbucket.org/%s/%s/changeset/%s", p.namespace, p.name, p.version), nil
 	case "apk":

--- a/internal/explore/purl_test.go
+++ b/internal/explore/purl_test.go
@@ -64,7 +64,7 @@ func TestPurl(t *testing.T) {
 		"https://github.com/package-url/purl-spec/tree/244fd47e07d1004f0aed9c",
 	}, {
 		"pkg:github/wolfi-dev/os@92940c6d5e40c38f076ad57ec660e765f8ef2e7a#openssl.yaml",
-		"https://github.com/wolfi-dev/os/blob/92940c6d5e40c38f076ad57ec660e765f8ef2e7a/openssl.yaml",
+		"https://github.com/wolfi-dev/os/tree/92940c6d5e40c38f076ad57ec660e765f8ef2e7a/openssl.yaml",
 		//}, {
 		//"pkg:apk/alpine/foo@1.2.3?arch=x86_64",
 		//"https://pkgs.alpinelinux.org/packages?name=foo&branch=edge&arch=x86_64",

--- a/internal/explore/purl_test.go
+++ b/internal/explore/purl_test.go
@@ -1,7 +1,6 @@
 package explore
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func FuzzPurl(f *testing.F) {
 	f.Fuzz(func(t *testing.T, s string) {
 		// Test that parsing doesn't panic.
 		_, _ = parsePurl(s)
-		fmt.Print(s)
+		t.Log(s)
 	})
 }
 
@@ -64,8 +63,11 @@ func TestPurl(t *testing.T) {
 		"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
 		"https://github.com/package-url/purl-spec/tree/244fd47e07d1004f0aed9c",
 	}, {
-		"pkg:apk/alpine/foo@1.2.3?arch=x86_64",
-		"https://pkgs.alpinelinux.org/packages?name=foo&branch=edge&arch=x86_64",
+		"pkg:github/wolfi-dev/os@92940c6d5e40c38f076ad57ec660e765f8ef2e7a#openssl.yaml",
+		"https://github.com/wolfi-dev/os/blob/92940c6d5e40c38f076ad57ec660e765f8ef2e7a/openssl.yaml",
+		//}, {
+		//"pkg:apk/alpine/foo@1.2.3?arch=x86_64",
+		//"https://pkgs.alpinelinux.org/packages?name=foo&branch=edge&arch=x86_64",
 		//}, {
 		//	"pkg:golang/google.golang.org/genproto#googleapis/api/annotations", "",
 		//}, {


### PR DESCRIPTION
Example: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk@sha1:43f672e68bd84aeda9fef54bafa0e0540d5ef004/var/lib/db/sbom/libcrypto3-3.3.1-r3.spdx.json

This includes a link that could go to a subpath:

```
{
  "referenceCategory": "PACKAGE_MANAGER",
  "referenceLocator": "pkg:github/wolfi-dev/os@92940c6d5e40c38f076ad57ec660e765f8ef2e7a#openssl.yaml",
  "referenceType": "purl"
}
```

The locator links to https://github.com/wolfi-dev/os/tree/92940c6d5e40c38f076ad57ec660e765f8ef2e7a when it could link to https://github.com/wolfi-dev/os/blob/92940c6d5e40c38f076ad57ec660e765f8ef2e7a/openssl.yaml

I commented out a test because it was failing for me:

```
--- FAIL: TestPurl (0.00s)
    purl_test.go:99: purl("pkg:apk/alpine/foo@1.2.3?arch=x86_64").url():
got:  "https://apk.dag.dev/https/dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/foo-1.2.3.apk",
want: "https://pkgs.alpinelinux.org/packages?name=foo&branch=edge&arch=x86_64"
```