### PR TITLE
Switch from `humanize.Bytes` to `humanize.IBytes`

### DIFF
--- a/internal/apk/index.go
+++ b/internal/apk/index.go
@@ -402,7 +402,7 @@ func (h *handler) renderExpanded(w http.ResponseWriter, r *http.Request, open fu
 				return fmt.Errorf("parsing %q as int: %w", after, err)
 			}
 			if !isCurl {
-				prevLines = append(prevLines, fmt.Sprintf("%s:<span title=%q>%s</span>", before, humanize.Bytes(uint64(i)), after))
+				prevLines = append(prevLines, fmt.Sprintf("%s:<span title=%q>%s</span>", before, humanize.IBytes(uint64(i)), after))
 			} else {
 				prevLines = append(prevLines, fmt.Sprintf("%s:%s", before, after))
 			}
@@ -928,7 +928,7 @@ func (h *handler) renderPkgInfo(w http.ResponseWriter, r *http.Request, in io.Re
 			if err != nil {
 				return fmt.Errorf("parsing %q as int: %w", after, err)
 			}
-			fmt.Fprintf(w, "%s = <a title=%q href=%q>%s</a>\n", before, humanize.Bytes(uint64(i)), sizeHref, after)
+			fmt.Fprintf(w, "%s = <a title=%q href=%q>%s</a>\n", before, humanize.IBytes(uint64(i)), sizeHref, after)
 		case "builddate":
 			sec, err := strconv.ParseInt(after, 10, 64)
 			if err != nil {

--- a/internal/apk/render.go
+++ b/internal/apk/render.go
@@ -1101,7 +1101,7 @@ func renderMap(w *jsonOutputter, o map[string]interface{}, raw *json.RawMessage)
 						if err == nil {
 							// TODO: dedupe with Value
 							w.tabf()
-							w.Print(fmt.Sprintf(`"<span title="%s">%s</span>"`, humanize.Bytes(uint64(bs)), s))
+							w.Print(fmt.Sprintf(`"<span title="%s">%s</span>"`, humanize.IBytes(uint64(bs)), s))
 							w.unfresh()
 							w.key = false
 							// Don't fall through to renderRaw.
@@ -1121,7 +1121,7 @@ func renderMap(w *jsonOutputter, o map[string]interface{}, raw *json.RawMessage)
 								if ms, ok := m.(string); ok {
 									if shouldSize(ms) {
 										w.tabf()
-										w.Print(fmt.Sprintf(`<a href="/size/%s@%s?mt=%s&size=%d"><span title="%s">%d</span></a>`, w.repo, ds, ms, int64(bs), humanize.Bytes(n), n))
+										w.Print(fmt.Sprintf(`<a href="/size/%s@%s?mt=%s&size=%d"><span title="%s">%d</span></a>`, w.repo, ds, ms, int64(bs), humanize.IBytes(n), n))
 										w.unfresh()
 										w.key = false
 										// Don't fall through to renderRaw.
@@ -1133,7 +1133,7 @@ func renderMap(w *jsonOutputter, o map[string]interface{}, raw *json.RawMessage)
 					}
 
 					w.tabf()
-					w.Print(fmt.Sprintf(`<span title="%s">%d</span>`, humanize.Bytes(n), n))
+					w.Print(fmt.Sprintf(`<span title="%s">%d</span>`, humanize.IBytes(n), n))
 					w.unfresh()
 					w.key = false
 					// Don't fall through to renderRaw.

--- a/internal/explore/dockerfile.go
+++ b/internal/explore/dockerfile.go
@@ -81,7 +81,7 @@ func renderDockerfileSchema1(w io.Writer, b []byte, repo name.Repository) error 
 		fmt.Fprintf(w, "<tr>\n")
 		fmt.Fprintf(w, "<td class=\"noselect\"><p><a href=%q><em>%s</em></a></p></td>\n", href, digest)
 		if size != 0 {
-			human := humanize.Bytes(uint64(size))
+			human := humanize.IBytes(uint64(size))
 			fmt.Fprintf(w, "<td class=\"noselect\"><p title=\"%d bytes\">%s</p></td>\n", size, human)
 		} else {
 			fmt.Fprintf(w, "<td></td>\n")
@@ -132,7 +132,7 @@ func renderDockerfile(w io.Writer, b []byte, m *v1.Manifest, repo name.Repositor
 		fmt.Fprintf(w, "<tr>\n")
 		fmt.Fprintf(w, "<td class=\"noselect\"><p><a href=%q><em>%s</em></a></p></td>\n", href, digest)
 		if size != 0 {
-			human := humanize.Bytes(uint64(size))
+			human := humanize.IBytes(uint64(size))
 			fmt.Fprintf(w, "<td class=\"noselect\"><p title=\"%d bytes\">%s</p></td>\n", size, human)
 		} else {
 			fmt.Fprintf(w, "<td></td>\n")

--- a/internal/explore/render.go
+++ b/internal/explore/render.go
@@ -1232,7 +1232,7 @@ func renderMap(w *jsonOutputter, o map[string]interface{}, raw *json.RawMessage)
 						if err == nil {
 							// TODO: dedupe with Value
 							w.tabf()
-							w.Print(fmt.Sprintf(`"<span title="%s">%s</span>"`, humanize.Bytes(uint64(bs)), s))
+							w.Print(fmt.Sprintf(`"<span title="%s">%s</span>"`, humanize.IBytes(uint64(bs)), s))
 							w.unfresh()
 							w.key = false
 							// Don't fall through to renderRaw.
@@ -1252,7 +1252,7 @@ func renderMap(w *jsonOutputter, o map[string]interface{}, raw *json.RawMessage)
 								if ms, ok := m.(string); ok {
 									if shouldSize(ms) {
 										w.tabf()
-										w.Print(fmt.Sprintf(`<a href="/size/%s@%s?mt=%s&size=%d"><span title="%s">%d</span></a>`, w.repo, ds, ms, int64(bs), humanize.Bytes(n), n))
+										w.Print(fmt.Sprintf(`<a href="/size/%s@%s?mt=%s&size=%d"><span title="%s">%d</span></a>`, w.repo, ds, ms, int64(bs), humanize.IBytes(n), n))
 										w.unfresh()
 										w.key = false
 										// Don't fall through to renderRaw.
@@ -1264,7 +1264,7 @@ func renderMap(w *jsonOutputter, o map[string]interface{}, raw *json.RawMessage)
 					}
 
 					w.tabf()
-					w.Print(fmt.Sprintf(`<span title="%s">%d</span>`, humanize.Bytes(n), n))
+					w.Print(fmt.Sprintf(`<span title="%s">%d</span>`, humanize.IBytes(n), n))
 					w.unfresh()
 					w.key = false
 					// Don't fall through to renderRaw.

--- a/internal/forks/http/fs.go
+++ b/internal/forks/http/fs.go
@@ -491,7 +491,7 @@ func tarListAll(i int, dirs anyDirs, fi fs.FileInfo, u url.URL, uprefix, fprefix
 	ug := fmt.Sprintf("%d/%d", header.Uid, header.Gid)
 	mode := modeStr(header)
 	padding := 18 - len(ug)
-	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.Bytes(uint64(header.Size)), padding, header.Size, ts)
+	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.IBytes(uint64(header.Size)), padding, header.Size, ts)
 
 	name := dirs.name(i)
 	if header.Linkname != "" {
@@ -548,7 +548,7 @@ func tarList(i int, dirs anyDirs, showlayer bool, fi fs.FileInfo, u url.URL, upr
 	ug := fmt.Sprintf("%d/%d", header.Uid, header.Gid)
 	mode := modeStr(header)
 	padding := 18 - len(ug)
-	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.Bytes(uint64(header.Size)), padding, header.Size, ts)
+	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.IBytes(uint64(header.Size)), padding, header.Size, ts)
 	if showlayer {
 		if _, after, ok := strings.Cut(layer, "@"); ok {
 			if _, after, ok := strings.Cut(after, ":"); ok {
@@ -628,7 +628,7 @@ func tarListSize(i int, dirs anyDirs, showlayer bool, fi fs.FileInfo, u url.URL,
 	ug := fmt.Sprintf("%d/%d", header.Uid, header.Gid)
 	mode := modeStr(header)
 	padding := 18 - len(ug)
-	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.Bytes(uint64(header.Size)), padding, header.Size, ts)
+	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.IBytes(uint64(header.Size)), padding, header.Size, ts)
 	if showlayer {
 		if _, after, ok := strings.Cut(layer, "@"); ok {
 			if _, after, ok := strings.Cut(after, ":"); ok {
@@ -702,7 +702,7 @@ func TarList(fi fs.FileInfo, u url.URL, uprefix string) string {
 	ug := fmt.Sprintf("%d/%d", header.Uid, header.Gid)
 	mode := modeStr(header)
 	padding := 18 - len(ug)
-	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.Bytes(uint64(header.Size)), padding, header.Size, ts)
+	s := fmt.Sprintf("%s %s <span title=%q>%*d</span> %s", mode, ug, humanize.IBytes(uint64(header.Size)), padding, header.Size, ts)
 	name := fi.Name()
 	if header.Linkname != "" {
 		if header.Linkname == "." {


### PR DESCRIPTION
The former uses base 10 (are we hard drive manufacturers trying to mislead our customers??), while the latter uses the more correct/industry standard base 2.