### PR TITLE
Add multiauth keychains

### DIFF
--- a/cmd/apk/main.go
+++ b/cmd/apk/main.go
@@ -47,13 +47,15 @@ func main() {
 	}
 	log.Printf("listening on %s", port)
 
-	// TODO: Auth.
 	opt := []apk.Option{apk.WithUserAgent(userAgent)}
 	if *auth || os.Getenv("AUTH") == "keychain" {
 		opt = append(opt, apk.WithKeychain(gcrane.Keychain))
 	}
 	if cgid := os.Getenv("CHAINGUARD_IDENTITY"); cgid != "" {
-		cgauth := apk.NewChainguardIdentityAuth(cgid, "https://issuer.enforce.dev", "apk.cgr.dev")
+		cgauth, err := apk.NewChainguardMultiKeychain(cgid, "https://issuer.enforce.dev", "apk.cgr.dev")
+		if err != nil {
+			log.Fatalf("error creating apk auth keychain: %v", err)
+		}
 		opt = append(opt, apk.WithAuth(cgauth))
 	}
 	if eg := os.Getenv("EXAMPLES"); eg != "" {

--- a/cmd/oci/main.go
+++ b/cmd/oci/main.go
@@ -50,7 +50,10 @@ func main() {
 	opt := []explore.Option{explore.WithUserAgent(userAgent)}
 	kcs := []authn.Keychain{}
 	if cgid := os.Getenv("CHAINGUARD_IDENTITY"); cgid != "" {
-		cgauth := explore.NewChainguardIdentityAuth(cgid, "https://issuer.enforce.dev", "cgr.dev")
+		cgauth, err := explore.NewChainguardMultiKeychain(cgid, "https://issuer.enforce.dev", "cgr.dev")
+		if err != nil {
+			log.Fatalf("error creating OCI auth keychain: %v", err)
+		}
 		kcs = append(kcs, cgauth)
 	}
 	if *auth || os.Getenv("AUTH") == "keychain" {

--- a/internal/apk/auth_test.go
+++ b/internal/apk/auth_test.go
@@ -1,0 +1,61 @@
+package apk
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type mockAuth struct {
+	token string
+}
+
+func (m *mockAuth) AddAuth(ctx context.Context, req *http.Request) error {
+	if m.token != "" {
+		req.SetBasicAuth("user", m.token)
+	}
+	return nil
+}
+
+func TestNewMultiAuthenticator(t *testing.T) {
+	auth := NewMultiAuthenticator(&mockAuth{}, &mockAuth{token: "foo"})
+	req := httptest.NewRequest("GET", "/", nil)
+	if err := auth.AddAuth(context.Background(), req); err != nil {
+		t.Fatalf("NewMultiAuthenticator() error = %v", err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:foo"))
+	got := req.Header.Get("Authorization")
+	if got != want {
+		t.Errorf("Authorization = %v, want %v", string(got), want)
+	}
+}
+
+func TestNewChainguardMultiKeychain(t *testing.T) {
+	_, err := NewChainguardMultiKeychain("uidp,chainguard://uidp@apk.cgr.dev?iss=issuer.enforce.dev", "foo", "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewChainguardIdentityAuthFromURL(t *testing.T) {
+	auth, err := NewChainguardIdentityAuthFromURL("chainguard://uidp@apk.cgr.dev?iss=issuer.enforce.dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cgauth, ok := auth.(*cgAuth)
+	if !ok {
+		t.Fatalf("NewChainguardIdentityAuthFromURL() = %T, want *cgAuth", auth)
+	}
+
+	if cgauth.id != "uidp" {
+		t.Errorf("id = %v, want uidp", cgauth.id)
+	}
+	if cgauth.iss != "https://issuer.enforce.dev" {
+		t.Errorf("iss = %v, want https://issuer.enforce.dev", cgauth.iss)
+	}
+	if cgauth.aud != "apk.cgr.dev" {
+		t.Errorf("aud = %v, want apk.cgr.dev", cgauth.aud)
+	}
+}

--- a/internal/chainguard/auth.go
+++ b/internal/chainguard/auth.go
@@ -1,0 +1,35 @@
+package chainguard
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type Identity struct {
+	ID, Issuer, Audience string
+}
+
+func ParseIdentity(raw string) (*Identity, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL: %w", err)
+	}
+
+	if u.Scheme != "chainguard" {
+		return nil, fmt.Errorf("invalid scheme %q", u.Scheme)
+	}
+
+	iss := u.Query().Get("iss")
+	if iss == "" {
+		return nil, fmt.Errorf("missing issuer query parameter")
+	}
+	if !strings.HasPrefix(iss, "https://") {
+		iss = "https://" + iss
+	}
+	return &Identity{
+		ID:       u.User.Username(),
+		Issuer:   iss,
+		Audience: u.Hostname(),
+	}, nil
+}

--- a/internal/chainguard/auth_test.go
+++ b/internal/chainguard/auth_test.go
@@ -1,0 +1,47 @@
+package chainguard
+
+import (
+	"testing"
+)
+
+func TestNewChainguardIdentityAuthFromURL(t *testing.T) {
+	cases := []struct {
+		rawURL  string
+		wantErr bool
+		wantID  string
+		wantIss string
+		wantAud string
+	}{
+		{
+			rawURL:  "chainguard://uidp@cgr.dev?iss=issuer.enforce.dev",
+			wantErr: false,
+			wantID:  "uidp",
+			wantIss: "https://issuer.enforce.dev",
+			wantAud: "cgr.dev",
+		},
+		{
+			rawURL:  "invalid-url",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.rawURL, func(t *testing.T) {
+			got, err := ParseIdentity(tc.rawURL)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewChainguardIdentityAuthFromURL() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err == nil {
+				if got.ID != tc.wantID {
+					t.Errorf("id = %v, want %v", got.ID, tc.wantID)
+				}
+				if got.Issuer != tc.wantIss {
+					t.Errorf("iss = %v, want %v", got.Issuer, tc.wantIss)
+				}
+				if got.Audience != tc.wantAud {
+					t.Errorf("aud = %v, want %v", got.Audience, tc.wantAud)
+				}
+			}
+		})
+	}
+}

--- a/internal/explore/auth_test.go
+++ b/internal/explore/auth_test.go
@@ -1,0 +1,31 @@
+package explore
+
+import "testing"
+
+func TestNewChainguardIdentityAuthFromURL(t *testing.T) {
+	auth, err := NewChainguardIdentityAuthFromURL("chainguard://uidp@apk.cgr.dev?iss=issuer.enforce.dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cgauth, ok := auth.(*keychain)
+	if !ok {
+		t.Fatalf("NewChainguardIdentityAuthFromURL() = %T, want *cgAuth", auth)
+	}
+
+	if cgauth.id != "uidp" {
+		t.Errorf("id = %v, want uidp", cgauth.id)
+	}
+	if cgauth.iss != "https://issuer.enforce.dev" {
+		t.Errorf("iss = %v, want https://issuer.enforce.dev", cgauth.iss)
+	}
+	if cgauth.aud != "apk.cgr.dev" {
+		t.Errorf("aud = %v, want apk.cgr.dev", cgauth.aud)
+	}
+}
+
+func TestNewChainguardMultiKeychain(t *testing.T) {
+	_, err := NewChainguardMultiKeychain("uidp,chainguard://uidp@cgr.dev?iss=issuer.enforce.dev", "foo", "bar")
+	if err != nil {
+		t.Fatalf("NewChainguardMultiKeychain() error = %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,7 +49,10 @@ func run(args []string) error {
 			opt = append(opt, apk.WithKeychain(gcrane.Keychain))
 		}
 		if cgid := os.Getenv("CHAINGUARD_IDENTITY"); cgid != "" {
-			cgauth := apk.NewChainguardIdentityAuth(cgid, "https://issuer.enforce.dev", "apk.cgr.dev")
+			cgauth, err := apk.NewChainguardMultiKeychain(cgid, "https://issuer.enforce.dev", "apk.cgr.dev")
+			if err != nil {
+				return fmt.Errorf("error creating apk auth keychain: %w", err)
+			}
 			opt = append(opt, apk.WithAuth(cgauth))
 		}
 		if eg := os.Getenv("EXAMPLES"); eg != "" {
@@ -68,7 +71,10 @@ func run(args []string) error {
 		kcs := []authn.Keychain{}
 		if cgid := os.Getenv("CHAINGUARD_IDENTITY"); cgid != "" {
 			log.Printf("saw CHAINGUARD_IDENTITY=%q", cgid)
-			cgauth := explore.NewChainguardIdentityAuth(cgid, "https://issuer.enforce.dev", "cgr.dev")
+			cgauth, err := explore.NewChainguardMultiKeychain(cgid, "https://issuer.enforce.dev", "cgr.dev")
+			if err != nil {
+				return fmt.Errorf("error creating OCI auth keychain: %w", err)
+			}
 			kcs = append(kcs, cgauth)
 		}
 		if *auth || os.Getenv("AUTH") == "keychain" {


### PR DESCRIPTION
Adds support for multiauth keychaings for chainguard authentication. We primarily want this to allow authentication for multiple hosts (e.g. staging and test instances). This creates a new URL-based schema for specifying Chainguard identities of the form
`chainguard://uidp@cgr.dev?iss=issuer.enforce.dev` that encodes all of the identity information we need into a string that we can pass into the CHAINGUARD_IDENTITY environment var.

Backwards compatibility was kept with the existing env var format.