### PR TITLE
Add new extra-package repository urls

### DIFF
--- a/internal/apk/apk.go
+++ b/internal/apk/apk.go
@@ -53,6 +53,8 @@ var defaultExamples = []string{
 	"packages.cgr.dev/extras/x86_64",
 	"apk.cgr.dev/chainguard/aarch64",
 	"apk.cgr.dev/chainguard/x86_64",
+	"apk.cgr.dev/extra-packages/aarch64",
+	"apk.cgr.dev/extra-packages/x86_64",
 	"dl-cdn.alpinelinux.org/alpine/edge/main/aarch64",
 	"dl-cdn.alpinelinux.org/alpine/edge/main/armhf",
 	"dl-cdn.alpinelinux.org/alpine/edge/main/armv7",


### PR DESCRIPTION
Fixes #133 
New extras repo exists so adding those URLs.

Are the older packages.* ones still active? If not, should we remove them?