### PR TITLE
Support non-sha256 digest algorithms when fetching manifests by digest

### DIFF
--- a/pkg/ggcr/remote/descriptor.go
+++ b/pkg/ggcr/remote/descriptor.go
@@ -251,7 +251,15 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 		return nil, nil, fmt.Errorf("manifest is bigger than %d", f.options.maxSize)
 	}
 
-	digest, size, err := v1.SHA256(bytes.NewReader(manifest))
+	// When pulling by digest, use the same algorithm as requested so the
+	// comparison succeeds for non-sha256 algorithms (e.g. sha512).
+	algorithm := "sha256"
+	if dgst, ok := ref.(name.Digest); ok {
+		if h, err := v1.NewHash(dgst.DigestStr()); err == nil {
+			algorithm = h.Algorithm
+		}
+	}
+	digest, size, err := v1.HashWith(algorithm, bytes.NewReader(manifest))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ggcr/v1/hash.go
+++ b/pkg/ggcr/v1/hash.go
@@ -101,13 +101,21 @@ func (h *Hash) parse(unquoted string) error {
 
 // SHA256 computes the Hash of the provided io.Reader's content.
 func SHA256(r io.Reader) (Hash, int64, error) {
-	hasher := crypto.SHA256.New()
+	return HashWith("sha256", r)
+}
+
+// HashWith computes the Hash of the provided io.Reader's content using the named algorithm.
+func HashWith(algorithm string, r io.Reader) (Hash, int64, error) {
+	hasher, err := Hasher(algorithm)
+	if err != nil {
+		return Hash{}, 0, err
+	}
 	n, err := io.Copy(hasher, r)
 	if err != nil {
 		return Hash{}, 0, err
 	}
 	return Hash{
-		Algorithm: "sha256",
-		Hex:       hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size()))),
+		Algorithm: algorithm,
+		Hex:       hex.EncodeToString(hasher.Sum(nil)),
 	}, n, nil
 }

--- a/pkg/ggcr/v1/v1_test.go
+++ b/pkg/ggcr/v1/v1_test.go
@@ -103,6 +103,38 @@ func TestHashJSON(t *testing.T) {
 	}
 }
 
+func TestHashWith(t *testing.T) {
+	// sha256 via HashWith must match SHA256.
+	want, wantN, err := SHA256(strings.NewReader("hello world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, gotN, err := HashWith("sha256", strings.NewReader("hello world"))
+	if err != nil {
+		t.Fatalf("HashWith(sha256): %v", err)
+	}
+	if got != want || gotN != wantN {
+		t.Errorf("HashWith(sha256) = %v/%d, want %v/%d", got, gotN, want, wantN)
+	}
+
+	// sha512 of the empty string has a well-known value.
+	const wantSHA512Empty = "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+	h, n, err := HashWith("sha512", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("HashWith(sha512, empty): %v", err)
+	}
+	if h.String() != wantSHA512Empty {
+		t.Errorf("HashWith(sha512, empty) = %q, want %q", h.String(), wantSHA512Empty)
+	}
+	if n != 0 {
+		t.Errorf("HashWith(sha512, empty) size = %d, want 0", n)
+	}
+
+	if _, _, err := HashWith("md5", strings.NewReader("")); err == nil {
+		t.Error("HashWith(md5) should fail")
+	}
+}
+
 func TestHasher(t *testing.T) {
 	if h, err := Hasher("sha256"); err != nil || h == nil || h.Size() != 32 {
 		t.Errorf("Hasher(sha256) = %v, err = %v", h, err)


### PR DESCRIPTION
`fetchManifest` always computed the sha256 of the response body and then compared it against the requested digest. When pulling by a sha512 digest reference, the comparison always failed because it was diffing algorithms, not just values.

Add `HashWith(algorithm, r)` to `pkg/ggcr/v1` and refactor `SHA256` to delegate to it. In `fetchManifest`, detect the algorithm from the requested digest and hash with that algorithm instead of hardcoding sha256.

Upstream google/go-containerregistry has the same bug and only supports sha256 in `Hasher`, so this is a dagdotdev-only fix.

Add `TestHashWith` covering sha256 delegation, sha512 correctness, and the unsupported-algorithm error path.

"claude my eyes right out"