### PR TITLE
Extend non-sha256 digest algorithm support to tag pulls, Descriptor verify, and hash registration

### DIFF
--- a/pkg/ggcr/remote/descriptor.go
+++ b/pkg/ggcr/remote/descriptor.go
@@ -27,9 +27,9 @@ import (
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/internal/redact"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/internal/verify"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/name"
-	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/transport"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/types"
+	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 )
 
 var (
@@ -251,22 +251,28 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 		return nil, nil, fmt.Errorf("manifest is bigger than %d", f.options.maxSize)
 	}
 
-	// When pulling by digest, use the same algorithm as requested so the
-	// comparison succeeds for non-sha256 algorithms (e.g. sha512).
+	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
+	contentDigest, contentDigestErr := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
+
+	// When pulling by digest, use the same algorithm as the requested digest so
+	// the comparison succeeds for non-sha256 algorithms (e.g. sha512).
+	// When pulling by tag, use the algorithm from the Docker-Content-Digest
+	// header so the reported digest matches what the registry uses.
+	// Fall back to sha256 if neither applies.
 	algorithm := "sha256"
 	if dgst, ok := ref.(name.Digest); ok {
 		if h, err := v1.NewHash(dgst.DigestStr()); err == nil {
 			algorithm = h.Algorithm
 		}
+	} else if contentDigestErr == nil {
+		algorithm = contentDigest.Algorithm
 	}
 	digest, size, err := v1.HashWith(algorithm, bytes.NewReader(manifest))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
-	contentDigest, err := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
-	if err == nil && mediaType == types.DockerManifestSchema1Signed {
+	if contentDigestErr == nil && mediaType == types.DockerManifestSchema1Signed {
 		// If we can parse the digest from the header, and it's a signed schema 1
 		// manifest, let's use that for the digest to appease older registries.
 		digest = contentDigest
@@ -434,4 +440,3 @@ func (f *fetcher) headBlob(h v1.Hash) (*http.Response, error) {
 
 	return resp, nil
 }
-

--- a/pkg/ggcr/v1/hash.go
+++ b/pkg/ggcr/v1/hash.go
@@ -16,6 +16,8 @@ package v1
 
 import (
 	"crypto"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"

--- a/pkg/ggcr/v1/v1_test.go
+++ b/pkg/ggcr/v1/v1_test.go
@@ -2,8 +2,6 @@ package v1
 
 import (
 	"bytes"
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"encoding/json"
 	"strings"
 	"testing"

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -24,8 +24,8 @@ import (
 	"hash"
 	"io"
 
-	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/and"
+	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 )
 
 // SizeUnknown is a sentinel value to indicate that the expected size is not known.
@@ -107,7 +107,7 @@ func Descriptor(d v1.Descriptor) error {
 		return errors.New("error verifying descriptor; Data == nil")
 	}
 
-	h, sz, err := v1.SHA256(bytes.NewReader(d.Data))
+	h, sz, err := v1.HashWith(d.Digest.Algorithm, bytes.NewReader(d.Data))
 	if err != nil {
 		return err
 	}

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -25,51 +25,67 @@ import (
 	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 )
 
-func mustHash(s string, t *testing.T) v1.Hash {
-	h, _, err := v1.SHA256(strings.NewReader(s))
+func mustHashWith(algo, s string, t *testing.T) v1.Hash {
+	h, _, err := v1.HashWith(algo, strings.NewReader(s))
 	if err != nil {
-		t.Fatalf("v1.SHA256(%s) = %v", s, err)
+		t.Fatalf("v1.HashWith(%s, %s) = %v", algo, s, err)
 	}
 	t.Logf("Hashed: %q -> %q", s, h)
 	return h
 }
 
-func TestVerificationFailure(t *testing.T) {
-	want := "This is the input string."
-	buf := bytes.NewBufferString(want)
+func mustHash(s string, t *testing.T) v1.Hash {
+	return mustHashWith("sha256", s, t)
+}
 
-	verified, err := ReadCloser(io.NopCloser(buf), int64(len(want)), mustHash("not the same", t))
-	if err != nil {
-		t.Fatal("ReadCloser() =", err)
-	}
-	if b, err := io.ReadAll(verified); err == nil {
-		t.Errorf("ReadAll() = %q; want verification error", string(b))
+func TestVerificationFailure(t *testing.T) {
+	for _, algo := range []string{"sha256", "sha512"} {
+		t.Run(algo, func(t *testing.T) {
+			want := "This is the input string."
+			buf := bytes.NewBufferString(want)
+
+			verified, err := ReadCloser(io.NopCloser(buf), int64(len(want)), mustHashWith(algo, "not the same", t))
+			if err != nil {
+				t.Fatal("ReadCloser() =", err)
+			}
+			if b, err := io.ReadAll(verified); err == nil {
+				t.Errorf("ReadAll() = %q; want verification error", string(b))
+			}
+		})
 	}
 }
 
 func TestVerification(t *testing.T) {
-	want := "This is the input string."
-	buf := bytes.NewBufferString(want)
+	for _, algo := range []string{"sha256", "sha512"} {
+		t.Run(algo, func(t *testing.T) {
+			want := "This is the input string."
+			buf := bytes.NewBufferString(want)
 
-	verified, err := ReadCloser(io.NopCloser(buf), int64(len(want)), mustHash(want, t))
-	if err != nil {
-		t.Fatal("ReadCloser() =", err)
-	}
-	if _, err := io.ReadAll(verified); err != nil {
-		t.Error("ReadAll() =", err)
+			verified, err := ReadCloser(io.NopCloser(buf), int64(len(want)), mustHashWith(algo, want, t))
+			if err != nil {
+				t.Fatal("ReadCloser() =", err)
+			}
+			if _, err := io.ReadAll(verified); err != nil {
+				t.Error("ReadAll() =", err)
+			}
+		})
 	}
 }
 
 func TestVerificationSizeUnknown(t *testing.T) {
-	want := "This is the input string."
-	buf := bytes.NewBufferString(want)
+	for _, algo := range []string{"sha256", "sha512"} {
+		t.Run(algo, func(t *testing.T) {
+			want := "This is the input string."
+			buf := bytes.NewBufferString(want)
 
-	verified, err := ReadCloser(io.NopCloser(buf), SizeUnknown, mustHash(want, t))
-	if err != nil {
-		t.Fatal("ReadCloser() =", err)
-	}
-	if _, err := io.ReadAll(verified); err != nil {
-		t.Error("ReadAll() =", err)
+			verified, err := ReadCloser(io.NopCloser(buf), SizeUnknown, mustHashWith(algo, want, t))
+			if err != nil {
+				t.Fatal("ReadCloser() =", err)
+			}
+			if _, err := io.ReadAll(verified); err != nil {
+				t.Error("ReadAll() =", err)
+			}
+		})
 	}
 }
 
@@ -109,7 +125,7 @@ func TestDescriptor(t *testing.T) {
 	}{{
 		err: errors.New("error verifying descriptor; Data == nil"),
 	}, {
-		err: errors.New(`error verifying Digest; got "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", want ":"`),
+		err: errors.New(`unsupported hash: ""`),
 		desc: v1.Descriptor{
 			Data: []byte("abc"),
 		},
@@ -129,6 +145,24 @@ func TestDescriptor(t *testing.T) {
 			Digest: v1.Hash{
 				Algorithm: "sha256",
 				Hex:       "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+			},
+		},
+	}, {
+		err: errors.New("error verifying Size; got 3, want 0"),
+		desc: v1.Descriptor{
+			Data: []byte("abc"),
+			Digest: v1.Hash{
+				Algorithm: "sha512",
+				Hex:       "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+			},
+		},
+	}, {
+		desc: v1.Descriptor{
+			Data: []byte("abc"),
+			Size: 3,
+			Digest: v1.Hash{
+				Algorithm: "sha512",
+				Hex:       "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
 			},
 		},
 	}} {


### PR DESCRIPTION
Follow-up to the previous commit which fixed digest-algorithm mismatch when fetching manifests by non-sha256 digest reference. Three remaining gaps:

- `fetchManifest` for tag pulls: read the `Docker-Content-Digest` response header before hashing so the computed digest uses the registry's algorithm rather than always sha256. Verifies the content matches — no blind trust in the header.
- `verify.Descriptor`: was hardcoded to sha256; now uses `d.Digest.Algorithm` so sha512 (and future algorithms) embedded data is verified correctly.
- `pkg/ggcr/v1/hash.go`: register `crypto/sha256` and `crypto/sha512` in the production package rather than only in test files, so any binary that imports this package has both algorithms available unconditionally.

Expand `verify` tests to cover sha512 for `ReadCloser` and `Descriptor`.