### PR TITLE
Add blake3 digest algorithm support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.9.1
+	github.com/zeebo/blake3 v0.2.4
 	golang.org/x/crypto v0.36.0
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/sync v0.13.0
@@ -42,6 +43,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/googleapis/gax-go/v2 v2.14.0 h1:f+jMrjBPl+DL9nI4IQzLUxMq7XrAqFYB7hBPq
 github.com/googleapis/gax-go/v2 v2.14.0/go.mod h1:lhBCnjdLrWRaPvLWhmc8IS24m9mr07qSYnHncrgo+zk=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
+github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -124,6 +126,12 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/detectors/gcp v1.29.0 h1:TiaiXB4DpGD3sdzNlYQxruQngn5Apwzi1X0DRhuGvDQ=

--- a/pkg/explore/registry.go
+++ b/pkg/explore/registry.go
@@ -13,8 +13,8 @@ import (
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/authn"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/logs"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/name"
-	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/remote"
+	v1 "github.com/jonjohnsonjr/dagdotdev/pkg/ggcr/v1"
 	"github.com/jonjohnsonjr/dagdotdev/pkg/verify"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
@@ -198,6 +198,24 @@ func (h *handler) listCatalog(w http.ResponseWriter, r *http.Request, ref name.R
 	}, err
 }
 
+// extractDigest extracts the leading digest token (e.g. "sha256:abc…" or "blake3:def…")
+// from s, which may have a trailing path component after the hex digits.
+func extractDigest(s string) (string, error) {
+	algo, _, ok := strings.Cut(s, ":")
+	if !ok {
+		return "", fmt.Errorf("no colon in digest: %q", s)
+	}
+	hasher, err := v1.Hasher(algo)
+	if err != nil {
+		return "", err
+	}
+	n := len(algo) + 1 + hasher.Size()*2
+	if len(s) < n {
+		return "", fmt.Errorf("digest too short: %q", s)
+	}
+	return s[:n], nil
+}
+
 // Fetch blob from registry or URL.
 func (h *handler) fetchBlob(w http.ResponseWriter, r *http.Request) (*sizeBlob, string, error) {
 	path, root, err := splitFsURL(r.URL.Path)
@@ -219,16 +237,9 @@ func (h *handler) fetchBlob(w http.ResponseWriter, r *http.Request) (*sizeBlob, 
 	if len(chunks) != 2 {
 		return nil, "", fmt.Errorf("not enough chunks: %s", path)
 	}
-	// 71 = len("sha256:") + 64
-	if len(chunks[1]) < 71 {
-		return nil, "", fmt.Errorf("second chunk too short: %s", chunks[1])
-	}
-
-	digest := ""
-	if strings.HasPrefix(chunks[1], "sha256:") {
-		digest = chunks[1][:71]
-	} else if strings.HasPrefix(chunks[1], "sha512:") {
-		digest = chunks[1][:135]
+	digest, err := extractDigest(chunks[1])
+	if err != nil {
+		return nil, "", err
 	}
 
 	ref := strings.Join([]string{chunks[0], digest}, "@")
@@ -278,16 +289,9 @@ func (h *handler) resolveUrl(w http.ResponseWriter, r *http.Request) (string, er
 	if len(chunks) != 2 {
 		return "", fmt.Errorf("not enough chunks: %s", path)
 	}
-	// 71 = len("sha256:") + 64
-	if len(chunks[1]) < 71 {
-		return "", fmt.Errorf("second chunk too short: %s", chunks[1])
-	}
-
-	digest := ""
-	if strings.HasPrefix(chunks[1], "sha256:") {
-		digest = chunks[1][:71]
-	} else if strings.HasPrefix(chunks[1], "sha512:") {
-		digest = chunks[1][:135]
+	digest, err := extractDigest(chunks[1])
+	if err != nil {
+		return "", err
 	}
 
 	ref := strings.Join([]string{chunks[0], digest}, "@")
@@ -375,16 +379,9 @@ func (h *handler) getDigest(w http.ResponseWriter, r *http.Request) (name.Digest
 	if len(chunks) != 2 {
 		return name.Digest{}, "", fmt.Errorf("not enough chunks: %s", path)
 	}
-	// 71 = len("sha256:") + 64
-	if len(chunks[1]) < 71 {
-		return name.Digest{}, "", fmt.Errorf("second chunk too short: %s", chunks[1])
-	}
-
-	digest := ""
-	if strings.HasPrefix(chunks[1], "sha256:") {
-		digest = chunks[1][:71]
-	} else if strings.HasPrefix(chunks[1], "sha512:") {
-		digest = chunks[1][:135]
+	digest, err := extractDigest(chunks[1])
+	if err != nil {
+		return name.Digest{}, "", err
 	}
 
 	ref := strings.Join([]string{chunks[0], digest}, "@")

--- a/pkg/ggcr/v1/hash.go
+++ b/pkg/ggcr/v1/hash.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/zeebo/blake3"
 )
 
 // Hash is an unqualified digest of some content, e.g. sha256:deadbeef
@@ -71,6 +73,8 @@ func Hasher(name string) (hash.Hash, error) {
 		return crypto.SHA256.New(), nil
 	case "sha512":
 		return crypto.SHA512.New(), nil
+	case "blake3":
+		return blake3.New(), nil
 	default:
 		return nil, fmt.Errorf("unsupported hash: %q", name)
 	}

--- a/pkg/ggcr/v1/v1_test.go
+++ b/pkg/ggcr/v1/v1_test.go
@@ -51,6 +51,12 @@ func TestNewHash(t *testing.T) {
 	if _, err := NewHash(validSha512); err != nil {
 		t.Errorf("NewHash sha512: %v", err)
 	}
+
+	// blake3 outputs 32 bytes = 64 hex chars, same width as sha256.
+	const validBlake3 = "blake3:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if _, err := NewHash(validBlake3); err != nil {
+		t.Errorf("NewHash blake3: %v", err)
+	}
 }
 
 func TestNewHashErrors(t *testing.T) {
@@ -128,6 +134,19 @@ func TestHashWith(t *testing.T) {
 		t.Errorf("HashWith(sha512, empty) size = %d, want 0", n)
 	}
 
+	// blake3 of the empty input has a well-known value.
+	const wantBlake3Empty = "blake3:af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+	h, n, err = HashWith("blake3", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("HashWith(blake3, empty): %v", err)
+	}
+	if h.String() != wantBlake3Empty {
+		t.Errorf("HashWith(blake3, empty) = %q, want %q", h.String(), wantBlake3Empty)
+	}
+	if n != 0 {
+		t.Errorf("HashWith(blake3, empty) size = %d, want 0", n)
+	}
+
 	if _, _, err := HashWith("md5", strings.NewReader("")); err == nil {
 		t.Error("HashWith(md5) should fail")
 	}
@@ -139,6 +158,9 @@ func TestHasher(t *testing.T) {
 	}
 	if h, err := Hasher("sha512"); err != nil || h == nil || h.Size() != 64 {
 		t.Errorf("Hasher(sha512) = %v, err = %v", h, err)
+	}
+	if h, err := Hasher("blake3"); err != nil || h == nil || h.Size() != 32 {
+		t.Errorf("Hasher(blake3) = %v, err = %v", h, err)
 	}
 	if _, err := Hasher("md5"); err == nil {
 		t.Errorf("Hasher(md5) should fail")

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -39,7 +39,7 @@ func mustHash(s string, t *testing.T) v1.Hash {
 }
 
 func TestVerificationFailure(t *testing.T) {
-	for _, algo := range []string{"sha256", "sha512"} {
+	for _, algo := range []string{"sha256", "sha512", "blake3"} {
 		t.Run(algo, func(t *testing.T) {
 			want := "This is the input string."
 			buf := bytes.NewBufferString(want)
@@ -56,7 +56,7 @@ func TestVerificationFailure(t *testing.T) {
 }
 
 func TestVerification(t *testing.T) {
-	for _, algo := range []string{"sha256", "sha512"} {
+	for _, algo := range []string{"sha256", "sha512", "blake3"} {
 		t.Run(algo, func(t *testing.T) {
 			want := "This is the input string."
 			buf := bytes.NewBufferString(want)
@@ -73,7 +73,7 @@ func TestVerification(t *testing.T) {
 }
 
 func TestVerificationSizeUnknown(t *testing.T) {
-	for _, algo := range []string{"sha256", "sha512"} {
+	for _, algo := range []string{"sha256", "sha512", "blake3"} {
 		t.Run(algo, func(t *testing.T) {
 			want := "This is the input string."
 			buf := bytes.NewBufferString(want)
@@ -163,6 +163,24 @@ func TestDescriptor(t *testing.T) {
 			Digest: v1.Hash{
 				Algorithm: "sha512",
 				Hex:       "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+			},
+		},
+	}, {
+		err: errors.New("error verifying Size; got 3, want 0"),
+		desc: v1.Descriptor{
+			Data: []byte("abc"),
+			Digest: v1.Hash{
+				Algorithm: "blake3",
+				Hex:       "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+			},
+		},
+	}, {
+		desc: v1.Descriptor{
+			Data: []byte("abc"),
+			Size: 3,
+			Digest: v1.Hash{
+				Algorithm: "blake3",
+				Hex:       "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
 			},
 		},
 	}} {


### PR DESCRIPTION
Extends the non-sha256 groundwork from 6ecf899 (https://github.com/jonjohnsonjr/dagdotdev/pull/136) and 6729ee3 (https://github.com/jonjohnsonjr/dagdotdev/pull/135) to cover blake3 via `github.com/zeebo/blake3`.

- `Hasher()` gains a `"blake3"` case; both blank imports (`crypto/sha256`, `crypto/sha512`) and the new `blake3` import live in `hash.go` alongside the function that needs them
- Replace three identical hardcoded sha256/sha512 length+prefix blocks in `registry.go` with a single `extractDigest()` helper that derives the expected digest length from `v1.Hasher(algo).Size()`, making it automatically correct for any supported algorithm
- Tests extended across `TestHasher`, `TestNewHash`, `TestHashWith`, the `ReadCloser` algo loops, and `TestDescriptor` to cover blake3